### PR TITLE
Extract esri loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# angular-cli-esri Change Log
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## Unreleased
+## Changed
+- extracted module loading code into esri-loader
+- EsriLoaderService functions return promises
+
+## 0.1.0
+### Added
+- lazy load ArcGIS API for JavaScript
+- material design layout w/ nav links to routes

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@angular/platform-browser-dynamic": "~2.1.0",
     "@angular/router": "~3.1.0",
     "core-js": "^2.4.1",
+    "esri-loader": "^0.1.0",
     "rxjs": "5.0.0-beta.12",
     "ts-helpers": "^1.1.1",
     "zone.js": "^0.6.23"

--- a/src/app/esri-loader.service.ts
+++ b/src/app/esri-loader.service.ts
@@ -12,12 +12,21 @@ export class EsriLoaderService {
     return isLoaded();
   }
 
-  // TODO: return a promise instead of taking callback
-  init(callback: Function, options?: Object) {
-    return bootstrap(callback, options);
+  // wrap bootstrap in a promise
+  load(options?: Object): Promise<Function> {
+    return new Promise((resolve) => {
+      bootstrap(resolve, options);
+    });
   }
 
-  // TODO: return a promise instead of taking callback
+  // wrap Dojo require in a promise
+  loadModules(modules: string[]): Promise<any> {
+    return new Promise((resolve) => {
+      dojoRequire(modules, resolve);
+    });
+  }
+
+  // convenience function to allow calling Dojo require w/ callback
   require(modules: string[], callback: Function) {
     return dojoRequire(modules, callback);
   }

--- a/src/app/esri-loader.service.ts
+++ b/src/app/esri-loader.service.ts
@@ -1,8 +1,7 @@
 import { Injectable } from '@angular/core';
-
-// a closure variable used to call the Dojo require() function
-// once we load the ArcGIS API for JavaScript on the page
-let dojoRequire;
+// TODO: why doesn't this work?
+// import { isLoaded, bootstrap, dojoRequire } from 'esri-loader';
+import { isLoaded, bootstrap, dojoRequire } from '../../node_modules/esri-loader/src/index';
 
 @Injectable()
 export class EsriLoaderService {
@@ -10,48 +9,16 @@ export class EsriLoaderService {
   constructor() { }
 
   isLoaded() {
-    // would like to just use window.require, but fucking typescript
-    return typeof window['require'] !== 'undefined';
+    return isLoaded();
   }
 
+  // TODO: return a promise instead of taking callback
   init(callback: Function, options?: Object) {
-    const opts = Object.assign({
-      // defalut to latest version of the ArcGIS API for JavaScript
-      url: window.location.protocol + '//js.arcgis.com/4.1'
-    }, options);
-
-    // don't reload API if it is already loaded
-    if (this.isLoaded()) {
-      callback(new Error('The ArcGIS API for JavaScript is already loaded.'));
-      return;
-    }
-
-    // create a script object whose source points to the API
-    const script = document.createElement('script');
-    script.type = 'text/javascript';
-    script.src = opts.url;
-
-    // once the script is loaded...
-    script.onload = () => {
-      // we can now use Dojo's require() to load esri and dojo AMD modules
-      dojoRequire = window['require'];
-
-      // let the caller know that the API has been successfully loaded
-      // and as a convenience, return the require function 
-      // in case they want to use it directly
-      callback(null, dojoRequire);
-    };
-
-    // load the script
-    document.body.appendChild(script);
+    return bootstrap(callback, options);
   }
 
-  // a thin wrapper around Dojo's require()
+  // TODO: return a promise instead of taking callback
   require(modules: string[], callback: Function) {
-    if (!this.isLoaded()) {
-      throw new Error('The ArcGIS API for JavaScript has not been loaded. You must first call init()');
-    } else {
-      dojoRequire(modules, callback);
-    }
+    return dojoRequire(modules, callback);
   }
 }

--- a/src/app/esri-map/esri-map.component.ts
+++ b/src/app/esri-map/esri-map.component.ts
@@ -25,20 +25,21 @@ export class EsriMapComponent implements OnInit {
       this._createMap();
     } else {
       // must load ArcGIS API for JavaScript on the page before creating the map
-      this.esriLoader.init((err, require) => {
-        if (err) {
-          console.error(err);
-          return;
-        }
+      this.esriLoader.load(esriLoaderOptions)
+      .then(() => {
         this._createMap();
-      }, esriLoaderOptions);
+      })
+      .catch(err => {
+        console.error(err);
+      });
     }
   }
 
   // load the map module and then
   // create a map at the root dom node of this component
   _createMap() {
-    this.esriLoader.require(['esri/map'], (Map) => {
+    this.esriLoader.loadModules(['esri/map'])
+    .then((Map) => {
       this.map = new Map(this.elRef.nativeElement.firstChild, {
         center: [-118, 34.5],
         zoom: 8,

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Input, ViewChild } from '@angular/core';
-import { MdMenuTrigger} from '@angular/material'
+import { MdMenuTrigger} from '@angular/material';
 
 @Component({
   selector: 'app-header',


### PR DESCRIPTION
resolves #3 
resolves #9 

For some reason, I was only able to use a relative `import` path. I was expecting to be able to use `import { isLoaded, bootstrap, dojoRequire } from 'esri-loader';` - I blame TypeScript.

@kgs916 the new promise based API of EsriLoaderService might help w/ #2 

@jwasilgeo - would love your thoughts on that^^^ API (esp function names) and the API of the newly released https://github.com/tomwayson/esri-loader